### PR TITLE
add nc2bin script for NT seaice concentrations (NSIDC-0051)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ $ python nc2bin_nsidc0081.py /path/to/existing/netcdf/NSIDC0081_SEAICE_PS_S25km_
   Wrote: ./nt_20211101_f18_nrt_s.bin
 ```
 
+### nsidc0051
+
+The `nsidc0051` directory contains a script for converting [Sea Ice Concentrations from Nimbus-7 SMMR and DMSP SSM/I-SSMIS Passive Microwave Data, Version 2
+](https://nsidc.org/data/nsidc-0051) NetCDF data to the original binary format
+from earlier versions. The script is written in `python`.
+
+The script takes the path to an NetCDF file as an argument and produces binary
+files corresponding to sea ice concentration estimates from the DMSP satellite
+(e.g., `n07`, `f08`, `f11`, `f13`, `f17`) contained in the NetCDF file.
+
+The script produces outputs in the directory from which the program was invoked.
+
+#### Python script
+
+Requires `netcdf4` python library.
+
+
+```
+$ python nc2bin_nsidc0051.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_N25km_19900301_v2.0.nc 
+  Wrote: ./nt_19900301_f08_v1.1_n.bin
+$ python nc2bin_nsidc0051.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_S25km_20201101_v2.0.nc 
+  Wrote: ./nt_20201101_f17_v1.1_s.bin
+```
+
 ## License
 
 See [LICENSE](LICENSE), unless otherwise stated in the README file with each subdirectory.

--- a/nsidc0051/nc2bin_nsidc0051.py
+++ b/nsidc0051/nc2bin_nsidc0051.py
@@ -1,0 +1,119 @@
+"""
+nc2bin_nsidc0051.py
+
+Sample usage:
+    python nc2bin_nsidc0051.py NSIDC0051_SEAICE_PS_N25km_20210828_v2.0.nc
+    python nc2bin_nsidc0051.py NSIDC0051_SEAICE_PS_S25km_20210828_v2.0.nc
+
+If the original binary files are placed in subdir orig/ and the output of
+this code is placed in a directory called checkfiles/ then simple bash
+loops to check pre-existing orig/ and these checkfiles/ might be:
+
+    d=19900301
+    sat=f08
+    binver=v1.1
+    echo "$d"
+    for h in n s; do
+      echo "  Hemisphere: $h";
+      binfn="nt_${d}_${sat}_${binver}_${h}.bin"
+      echo "    $binfn";
+      cmp -l orig/${binfn} checkfiles/${binfn}
+    done
+
+    d=20200901
+    sat=f17
+    binver=v1.1
+    echo "$d"
+    for h in n s; do
+      echo "  Hemisphere: $h";
+      binfn="nt_${d}_${sat}_${binver}_${h}.bin"
+      echo "    $binfn";
+      cmp -l orig/${binfn} checkfiles/${binfn}
+    done
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+outdir = './'
+os.makedirs(outdir, exist_ok=True)
+verstr = 'v1.1'
+
+fn0051_ = 'nt_{ymd}_{sat}_{verstr}_{h}.bin'
+
+
+def xwm(m='exiting in xwm'):
+    raise SystemExit(m)
+
+
+def get_fndate(fn):
+    ymd = re.findall(r'\d{7,8}', fn)[0]
+
+    return ymd
+
+
+def extract_orig_0051(ifn):
+    if 'N25' in ifn:
+        hemlet = 'n'
+    elif 'S25' in ifn:
+        hemlet = 's'
+    else:
+        raise RuntimeError(f'Could not find N25 or S25 in fn: {ifn}')
+
+    fndate = get_fndate(ifn)
+
+    ds = Dataset(ifn, 'r')
+    ds.set_auto_maskandscale(False)
+
+    # sat is first 3 chars of variable of form xxx_ICECON
+    sat_list = [key[:3] for key in list(ds.variables.keys()) if 'ICECON' in key]  # noqa
+
+    for sat in sat_list:
+        varname = f'{sat}_ICECON'
+
+        try:
+            var = ds.variables[varname]
+        except KeyError:
+            print(f'  No such conc var found: {varname}')
+            continue
+
+        vals = np.array(var).astype(np.uint8).flatten()
+
+        ofn = os.path.join(
+            outdir,
+            fn0051_.format(
+                ymd=fndate,
+                sat=sat.lower(),
+                h=hemlet,
+                verstr=verstr,
+            )
+        )
+
+        hdr = ds.variables[varname].legacy_binary_header
+
+        outbytes = np.concatenate(
+            (hdr.flatten(), vals)
+        )
+
+        outbytes.tofile(ofn)
+        print(f'  Wrote: {ofn}')
+
+
+if __name__ == '__main__':
+    try:
+        ifn = sys.argv[1]
+        assert os.path.isfile(ifn)
+    except IndexError:
+        print(f'Usage: python {Path(__file__).name} <fn>')
+        raise RuntimeError('No filename given')
+    except AssertionError:
+        print(f'Not a file: {ifn}')
+        raise RuntimeError('Given filename is not a file')
+
+    extract_orig_0051(ifn)

--- a/nsidc0051/nc2bin_nsidc0051.py
+++ b/nsidc0051/nc2bin_nsidc0051.py
@@ -32,7 +32,6 @@ loops to check pre-existing orig/ and these checkfiles/ might be:
     done
 """
 
-import os
 import re
 import sys
 from pathlib import Path
@@ -52,6 +51,7 @@ def get_fnver(fn):
 
 
 def get_fndate(fn):
+    # Extract the datestring of the filename: YYYYMMDD or YYYYMM
     try:
         # Attempt to file YYYYMMDD (daily)
         datestr = re.findall(r'\d{7,8}', fn)[0]
@@ -67,6 +67,7 @@ def get_fndate(fn):
 
 
 def extract_orig_0051(ifn, outdir, verstr):
+    # Writes the legacy-format-equivalent output file for each ICECON field
     if 'N25' in ifn:
         hemlet = 'n'
     elif 'S25' in ifn:
@@ -93,15 +94,13 @@ def extract_orig_0051(ifn, outdir, verstr):
 
         vals = np.array(var).astype(np.uint8).flatten()
 
-        ofn = os.path.join(
-            outdir,
+        ofn = Path(outdir) / \
             fn0051_.format(
                 datestr=fndate,
                 sat=sat.lower(),
                 h=hemlet,
                 verstr=verstr,
             )
-        )
 
         hdr = ds.variables[varname].legacy_binary_header
 
@@ -114,15 +113,15 @@ def extract_orig_0051(ifn, outdir, verstr):
 
 
 if __name__ == '__main__':
-    outdir = './extracted_bins'
-    os.makedirs(outdir, exist_ok=True)
+    outdir = Path('./extracted_bins')
+    outdir.mkdir(parents=True, exist_ok=True)
 
     # Filename template
     fn0051_ = 'nt_{datestr}_{sat}_{verstr}_{h}.bin'
 
     try:
-        ifn = sys.argv[1]
-        assert os.path.isfile(ifn)
+        ifn = Path(sys.argv[1])
+        assert ifn.is_file()
     except IndexError:
         print(f'Usage: python {Path(__file__).name} <fn>')
         raise RuntimeError('No filename given')
@@ -131,6 +130,6 @@ if __name__ == '__main__':
         raise RuntimeError('Given filename is not a file')
 
     # Note: The last version of the raw binary 0051 fns was "v1.1"
-    verstr = get_fnver(ifn)
+    verstr = get_fnver(str(ifn))
 
-    extract_orig_0051(ifn, outdir, verstr)
+    extract_orig_0051(str(ifn), outdir, verstr)


### PR DESCRIPTION
This PR adds code to convert netCDF files from NSIDC-0051 back to binary format.

Note: There is no need to merge this branch before nsidc0051 version 2.0 is released.