### PR TITLE
Generalize nc2bins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __PYCACHE__
 
+.*.swp
+

--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ $ python nc2bin_nsidc0081.py /path/to/existing/netcdf/NSIDC0081_SEAICE_PS_S25km_
   Wrote: ./nt_20211101_f18_nrt_s.bin
 ```
 
+### nsidc0051
+
+The `nsidc0051` directory contains a script for converting [Sea Ice Concentrations from Nimbus-7 SMMR and DMSP SSM/I-SSMIS Passive Microwave Data, Version 2
+](https://nsidc.org/data/nsidc-0051) NetCDF data to the original binary format
+from earlier versions. The script is written in `python`.
+
+The script takes the path to an NetCDF file as an argument and produces binary
+files corresponding to sea ice concentration estimates from the DMSP satellite
+(e.g., `n07`, `f08`, `f11`, `f13`, `f17`) contained in the NetCDF file.
+
+The script produces outputs in the directory from which the program was invoked.
+
+#### Python script
+
+Requires `netcdf4` python library.
+
+
+```
+$ python nc2bin_nsidc0051.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_N25km_19900301_v2.0.nc 
+  Wrote: ./nt_19900301_f08_v1.1_n.bin
+$ python nc2bin_nsidc0051.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_S25km_20201101_v2.0.nc 
+  Wrote: ./nt_20201101_f17_v1.1_s.bin
+```
+
 ## License
 
 See [LICENSE](LICENSE), unless otherwise stated in the README file with each subdirectory.

--- a/nsidc0051/nc2bin_nsidc0051.py
+++ b/nsidc0051/nc2bin_nsidc0051.py
@@ -1,0 +1,119 @@
+"""
+nc2bin_nsidc0051.py
+
+Sample usage:
+    python nc2bin_nsidc0051.py NSIDC0051_SEAICE_PS_N25km_20210828_v2.0.nc
+    python nc2bin_nsidc0051.py NSIDC0051_SEAICE_PS_S25km_20210828_v2.0.nc
+
+If the original binary files are placed in subdir orig/ and the output of
+this code is placed in a directory called checkfiles/ then simple bash
+loops to check pre-existing orig/ and these checkfiles/ might be:
+
+    d=19900301
+    sat=f08
+    binver=v1.1
+    echo "$d"
+    for h in n s; do
+      echo "  Hemisphere: $h";
+      binfn="nt_${d}_${sat}_${binver}_${h}.bin"
+      echo "    $binfn";
+      cmp -l orig/${binfn} checkfiles/${binfn}
+    done
+
+    d=20200901
+    sat=f17
+    binver=v1.1
+    echo "$d"
+    for h in n s; do
+      echo "  Hemisphere: $h";
+      binfn="nt_${d}_${sat}_${binver}_${h}.bin"
+      echo "    $binfn";
+      cmp -l orig/${binfn} checkfiles/${binfn}
+    done
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+outdir = './'
+os.makedirs(outdir, exist_ok=True)
+verstr = 'v1.1'
+
+fn0051_ = 'nt_{ymd}_{sat}_{verstr}_{h}.bin'
+
+
+def xwm(m='exiting in xwm'):
+    raise SystemExit(m)
+
+
+def get_fndate(fn):
+    ymd = re.findall(r'\d{7,8}', fn)[0]
+
+    return ymd
+
+
+def extract_orig_0051(ifn):
+    if 'N25' in ifn:
+        hemlet = 'n'
+    elif 'S25' in ifn:
+        hemlet = 's'
+    else:
+        raise RuntimeError(f'Could not find N25 or S25 in fn: {ifn}')
+
+    fndate = get_fndate(ifn)
+
+    ds = Dataset(ifn, 'r')
+    ds.set_auto_maskandscale(False)
+
+    # sat is first 3 chars of variable of form xxx_ICECON
+    sat_list = [key[:3] for key in list(ds.variables.keys()) if 'ICECON' in key]  # noqa
+
+    for sat in sat_list:
+        varname = f'{sat}_ICECON'
+
+        try:
+            var = ds.variables[varname]
+        except KeyError:
+            print(f'  No such conc var found: {varname}')
+            continue
+
+        vals = np.array(var).astype(np.uint8).flatten()
+
+        ofn = os.path.join(
+            outdir,
+            fn0051_.format(
+                ymd=fndate,
+                sat=sat.lower(),
+                h=hemlet,
+                verstr=verstr,
+            )
+        )
+
+        hdr = ds.variables[varname].legacy_binary_header
+
+        outbytes = np.concatenate(
+            (hdr.flatten(), vals)
+        )
+
+        outbytes.tofile(ofn)
+        print(f'  Wrote: {ofn}')
+
+
+if __name__ == '__main__':
+    try:
+        ifn = sys.argv[1]
+        assert os.path.isfile(ifn)
+    except IndexError:
+        print(f'Usage: python {Path(__file__).name} <fn>')
+        raise RuntimeError('No filename given')
+    except AssertionError:
+        print(f'Not a file: {ifn}')
+        raise RuntimeError('Given filename is not a file')
+
+    extract_orig_0051(ifn)

--- a/nsidc0051/nc2bin_nsidc0051.py
+++ b/nsidc0051/nc2bin_nsidc0051.py
@@ -32,7 +32,6 @@ loops to check pre-existing orig/ and these checkfiles/ might be:
     done
 """
 
-import os
 import re
 import sys
 from pathlib import Path
@@ -52,6 +51,7 @@ def get_fnver(fn):
 
 
 def get_fndate(fn):
+    # Extract the datestring of the filename: YYYYMMDD or YYYYMM
     try:
         # Attempt to file YYYYMMDD (daily)
         datestr = re.findall(r'\d{7,8}', fn)[0]
@@ -67,6 +67,7 @@ def get_fndate(fn):
 
 
 def extract_orig_0051(ifn, outdir, verstr):
+    # Writes the legacy-format-equivalent output file for each ICECON field
     if 'N25' in ifn:
         hemlet = 'n'
     elif 'S25' in ifn:
@@ -93,15 +94,13 @@ def extract_orig_0051(ifn, outdir, verstr):
 
         vals = np.array(var).astype(np.uint8).flatten()
 
-        ofn = os.path.join(
-            outdir,
+        ofn = Path(outdir) / \
             fn0051_.format(
                 datestr=fndate,
                 sat=sat.lower(),
                 h=hemlet,
                 verstr=verstr,
             )
-        )
 
         hdr = ds.variables[varname].legacy_binary_header
 
@@ -114,15 +113,15 @@ def extract_orig_0051(ifn, outdir, verstr):
 
 
 if __name__ == '__main__':
-    outdir = './extracted_bins'
-    os.makedirs(outdir, exist_ok=True)
+    outdir = Path('./extracted_bins')
+    outdir.mkdir(parents=True, exist_ok=True)
 
     # Filename template
     fn0051_ = 'nt_{datestr}_{sat}_{verstr}_{h}.bin'
 
     try:
-        ifn = sys.argv[1]
-        assert os.path.isfile(ifn)
+        ifn = Path(sys.argv[1])
+        assert ifn.is_file()
     except IndexError:
         print(f'Usage: python {Path(__file__).name} <fn>')
         raise RuntimeError('No filename given')
@@ -131,6 +130,6 @@ if __name__ == '__main__':
         raise RuntimeError('Given filename is not a file')
 
     # Note: The last version of the raw binary 0051 fns was "v1.1"
-    verstr = get_fnver(ifn)
+    verstr = get_fnver(str(ifn))
 
-    extract_orig_0051(ifn, outdir, verstr)
+    extract_orig_0051(str(ifn), outdir, verstr)

--- a/nsidc_conc/nc2bin_nsidc0051.py
+++ b/nsidc_conc/nc2bin_nsidc0051.py
@@ -1,0 +1,135 @@
+"""
+nc2bin_nsidc0051.py
+
+Sample usage:
+    python nc2bin_nsidc0051.py NSIDC0051_SEAICE_PS_N25km_20210828_v2.0.nc
+    python nc2bin_nsidc0051.py NSIDC0051_SEAICE_PS_S25km_20210828_v2.0.nc
+
+If the original binary files are placed in subdir orig/ and the output of
+this code is placed in a directory called checkfiles/ then simple bash
+loops to check pre-existing orig/ and these checkfiles/ might be:
+
+    d=19900301
+    sat=f08
+    binver=v1.1
+    echo "$d"
+    for h in n s; do
+      echo "  Hemisphere: $h";
+      binfn="nt_${d}_${sat}_${binver}_${h}.bin"
+      echo "    $binfn";
+      cmp -l orig/${binfn} checkfiles/${binfn}
+    done
+
+    d=20200901
+    sat=f17
+    binver=v1.1
+    echo "$d"
+    for h in n s; do
+      echo "  Hemisphere: $h";
+      binfn="nt_${d}_${sat}_${binver}_${h}.bin"
+      echo "    $binfn";
+      cmp -l orig/${binfn} checkfiles/${binfn}
+    done
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+def get_fnver(fn):
+    # Extract the version string from the filename
+    # Assumes filename of the form "..._v?[.?].nc"
+    vstr_loc = fn.find('_v')
+    endstr = fn[vstr_loc:]
+    verstr = endstr.replace('.nc', '')[1:]
+
+    return verstr
+
+
+def get_fndate(fn):
+    # Extract the datestring of the filename: YYYYMMDD or YYYYMM
+    try:
+        # Attempt to file YYYYMMDD (daily)
+        datestr = re.findall(r'\d{7,8}', fn)[0]
+    except IndexError:
+        # If no daily datestring found, try to find monthly (YYYYMM)
+        try:
+            datestr = re.findall(r'\d{5,6}', fn)[0]
+        except IndexError:
+            raise RuntimeError(
+                f'Unable to find YYYYMMDD or YYYYMM in filename: {fn}')
+
+    return datestr
+
+
+def extract_orig_0051(ifn, outdir, verstr):
+    # Writes the legacy-format-equivalent output file for each ICECON field
+    if 'N25' in ifn:
+        hemlet = 'n'
+    elif 'S25' in ifn:
+        hemlet = 's'
+    else:
+        raise RuntimeError(f'Could not find N25 or S25 in fn: {ifn}')
+
+    fndate = get_fndate(ifn)
+
+    ds = Dataset(ifn, 'r')
+    ds.set_auto_maskandscale(False)
+
+    # sat is first 3 chars of variable of form xxx_ICECON
+    sat_list = [key[:3] for key in list(ds.variables.keys()) if 'ICECON' in key]  # noqa
+
+    for sat in sat_list:
+        varname = f'{sat}_ICECON'
+
+        try:
+            var = ds.variables[varname]
+        except KeyError:
+            print(f'  No such conc var found: {varname}')
+            continue
+
+        vals = np.array(var).astype(np.uint8).flatten()
+
+        ofn = Path(outdir) / \
+            fn0051_.format(
+                datestr=fndate,
+                sat=sat.lower(),
+                h=hemlet,
+                verstr=verstr,
+            )
+
+        hdr = ds.variables[varname].legacy_binary_header
+
+        outbytes = np.concatenate(
+            (hdr.flatten(), vals)
+        )
+
+        outbytes.tofile(ofn)
+        print(f'  Wrote: {ofn}')
+
+
+if __name__ == '__main__':
+    outdir = Path('./extracted_bins')
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # Filename template
+    fn0051_ = 'nt_{datestr}_{sat}_{verstr}_{h}.bin'
+
+    try:
+        ifn = Path(sys.argv[1])
+        assert ifn.is_file()
+    except IndexError:
+        print(f'Usage: python {Path(__file__).name} <fn>')
+        raise RuntimeError('No filename given')
+    except AssertionError:
+        print(f'Not a file: {ifn}')
+        raise RuntimeError('Given filename is not a file')
+
+    # Note: The last version of the raw binary 0051 fns was "v1.1"
+    verstr = get_fnver(str(ifn))
+
+    extract_orig_0051(str(ifn), outdir, verstr)

--- a/nsidc_conc/nc2bin_nsidc0081.py
+++ b/nsidc_conc/nc2bin_nsidc0081.py
@@ -1,0 +1,101 @@
+"""
+nc2bin_nsidc0081.py
+
+Sample usage:
+    python nc2bin_nsidc0081.py NSIDC0081_SEAICE_PS_N25km_20210828_v2.0.nc
+    python nc2bin_nsidc0081.py NSIDC0081_SEAICE_PS_S25km_20210828_v2.0.nc
+
+If the original binary files are placed in subdir orig/ and the output of
+this code is placed in a directory called checkfiles/ then simple bash
+loops to check pre-existing orig/ and these checkfiles/ might be:
+
+    for d in 20210828 20210829; do
+        echo " ";
+      echo "$d"
+      for h in n s; do
+        echo "  Hemisphere: $h";
+        for sat in f16 f17 f18; do
+          binfn="nt_${d}_${sat}_nrt_${h}.bin"
+          echo "    $binfn";
+          cmp -l orig/${binfn} checkfiles/${binfn}
+        done
+        echo " "
+      done
+    done
+
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+outdir = './'
+os.makedirs(outdir, exist_ok=True)
+
+fn0081_ = 'nt_{ymd}_{sat}_nrt_{h}.bin'
+
+
+def get_fndate(fn):
+    ymd = re.findall(r'\d{7,8}', fn)[0]
+
+    return ymd
+
+
+def extract_orig_0081(ifn):
+    if 'N25' in ifn:
+        hemlet = 'n'
+    elif 'S25' in ifn:
+        hemlet = 's'
+    else:
+        raise RuntimeError(f'Could not find N25 or S25 in fn: {ifn}')
+
+    fndate = get_fndate(ifn)
+
+    ds = Dataset(ifn, 'r')
+    ds.set_auto_maskandscale(False)
+
+    for sat in ('F16', 'F17', 'F18'):
+        varname = f'{sat}_ICECON'
+
+        try:
+            var = ds.variables[varname]
+        except KeyError:
+            print(f'  No such conc var found: {varname}')
+            continue
+
+        vals = np.array(var).astype(np.uint8).flatten()
+
+        ofn = os.path.join(
+            outdir,
+            fn0081_.format(
+                ymd=fndate,
+                sat=sat.lower(),
+                h=hemlet))
+
+        hdr = ds.variables[varname].legacy_binary_header
+
+        outbytes = np.concatenate(
+            (hdr.flatten(), vals)
+        )
+
+        outbytes.tofile(ofn)
+        print(f'  Wrote: {ofn}')
+
+
+if __name__ == '__main__':
+    try:
+        ifn = sys.argv[1]
+        assert os.path.isfile(ifn)
+    except IndexError:
+        print(f'Usage: python {Path(__file__).name} <fn>')
+        raise RuntimeError('No filename given')
+    except AssertionError:
+        print(f'Not a file: {ifn}')
+        raise RuntimeError('Given filename is not a file')
+
+    extract_orig_0081(ifn)

--- a/nsidc_conc/nc2bin_nsidc_conc.py
+++ b/nsidc_conc/nc2bin_nsidc_conc.py
@@ -1,0 +1,179 @@
+"""
+nc2bin_nsidc_conc.py
+
+Converts NSIDC sea ice concentration fields from netCDF files -- currently
+  NSIDC-0051 and NSIDC-0081 -- to their legacy-equivalent raw binary file
+  names
+
+Sample usage:
+    python nc2bin_conc.py NSIDC0051_SEAICE_PS_N25km_20210828_v2.0.nc
+    python nc2bin_conc.py NSIDC0051_SEAICE_PS_S25km_20210828_v2.0.nc
+
+    python nc2bin_conc.py NSIDC0081_SEAICE_PS_N25km_20210828_v2.0.nc
+    python nc2bin_conc.py NSIDC0081_SEAICE_PS_S25km_20210828_v2.0.nc
+
+    python nc2bin_conc.py NSIDC0051_SEAICE_PS_N25km_202108_v2.0.nc
+    python nc2bin_conc.py NSIDC0051_SEAICE_PS_S25km_202108_v2.0.nc
+
+    python nc2bin_conc.py NSIDC0081_SEAICE_PS_N25km_202108_v2.0.nc
+    python nc2bin_conc.py NSIDC0081_SEAICE_PS_S25km_202108_v2.0.nc
+
+Input files can be:
+    0051 or 0081
+    daily or monthly
+    NH or SH
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+def get_fnver(prodid, fn):
+    # Extract the version string from the filename
+    # Assumes filename of the form "..._v?[.?].nc"
+    # Note: NRT products will return version string 'nrt'
+    if prodid == 'nsidc0081':
+        verstr = 'nrt'
+    else:
+        vstr_loc = fn.find('_v')
+        endstr = fn[vstr_loc:]
+        verstr = endstr.replace('.nc', '')[1:]
+
+    return verstr
+
+
+def get_fndate(fn):
+    # Extract the datestring of the filename: YYYYMMDD or YYYYMM
+    try:
+        # Attempt to file YYYYMMDD (daily)
+        datestr = re.findall(r'\d{7,8}', fn)[0]
+    except IndexError:
+        # If no daily datestring found, try to find monthly (YYYYMM)
+        try:
+            datestr = re.findall(r'\d{5,6}', fn)[0]
+        except IndexError:
+            raise RuntimeError(
+                f'Unable to find YYYYMMDD or YYYYMM in filename: {fn}')
+
+    return datestr
+
+
+def get_hemlet(fn):
+    # Extract the letter designating the hemisphere from the filename
+    if 'N25' in fn:
+        hemlet = 'n'
+    elif 'S25' in fn:
+        hemlet = 's'
+    else:
+        raise RuntimeError(f'Could not find N25 or S25 in fn: {fn}')
+    return hemlet
+
+
+def get_prodid(fn):
+    # Determine which NSIDC product is being used
+    #  Currently NSIDC-0051 and NSIDC-0081 are supported
+    prodid_dict = {
+        'nsidc0051': 'NSIDC0051',
+        'nsidc0081': 'NSIDC0081',
+    }
+
+    prod_id = None
+    for key in prodid_dict.keys():
+        val = prodid_dict[key]
+        if val in fn:
+            prod_id = key
+
+    if prod_id is None:
+        error_message = f"""
+        Product ID cannot be determined
+            File name: {fn}
+            valid product ids: {prodid_dict.keys()}
+        """
+        raise RuntimeError(error_message)
+
+    return prod_id
+
+
+def get_legacy_fn_template(prodid):
+    # Return a string template for the filename for this product id
+    # Note: for 0081, 'verstr' should evaluate to 'nrt' instead of a 
+    #       numbered version
+    legacy_fn_templates = {
+        'nsidc0051': 'nt_{datestr}_{sat}_{verstr}_{h}.bin',
+        'nsidc0081': 'nt_{datestr}_{sat}_{verstr}_{h}.bin',
+    } 
+    try:
+        fn_template = legacy_fn_templates[prodid]
+    except KeyError:
+        raise RuntimeError(f'No legacy filename template for prodid {prodid}')
+
+    return fn_template
+
+
+def extract_legacy_conc(ifn, outdir):
+    # Writes the legacy-format-equivalent output file for each ICECON field
+    
+    prod_id = get_prodid(ifn)
+    verstr = get_fnver(prod_id, ifn)
+    fn_template = get_legacy_fn_template(prod_id)
+    hemlet = get_hemlet(ifn)
+    fndate = get_fndate(ifn)
+
+    ds = Dataset(ifn, 'r')
+    ds.set_auto_maskandscale(False)
+
+    # sat is first 3 chars of variable of form xxx_ICECON
+    sat_list = [key[:3] for key in list(ds.variables.keys()) if 'ICECON' in key]  # noqa
+
+    for sat in sat_list:
+        varname = f'{sat}_ICECON'
+
+        try:
+            var = ds.variables[varname]
+        except KeyError:
+            print(f'  No such conc var found: {varname}')
+            continue
+
+        vals = np.array(var).astype(np.uint8).flatten()
+
+        ofn = Path(outdir) / \
+            fn_template.format(
+                datestr=fndate,
+                sat=sat.lower(),
+                h=hemlet,
+                verstr=verstr,
+            )
+
+        hdr = ds.variables[varname].legacy_binary_header
+
+        outbytes = np.concatenate(
+            (hdr.flatten(), vals)
+        )
+
+        outbytes.tofile(ofn)
+        print(f'  Wrote: {ofn}')
+
+
+if __name__ == '__main__':
+    try:
+        ifn = Path(sys.argv[1])
+        assert ifn.is_file()
+    except IndexError:
+        print(f'Usage: python {Path(__file__).name} <fn>')
+        raise RuntimeError('No filename given')
+    except AssertionError:
+        print(f'Not a file: {ifn}')
+        raise RuntimeError('Given filename is not a file')
+
+    # Filename template
+    # fn0051_ = 'nt_{datestr}_{sat}_{verstr}_{h}.bin'
+
+    outdir = Path('./extracted_bins')
+    outdir.mkdir(parents=True, exist_ok=True)
+    print(f'Writing extracted output to directory: {outdir}')
+
+    extract_legacy_conc(str(ifn), outdir)

--- a/nsidc_tb/nc2bin_nsidc_tb.py
+++ b/nsidc_tb/nc2bin_nsidc_tb.py
@@ -1,0 +1,120 @@
+"""
+nc2bin_nsidc_tb.py
+
+From a NSIDC brightness temperature netCDF file -- eg NSIDC0001 or
+NSIDC-0080 -- extract the tb fields and output in legacy format
+
+Sample usage:
+    python nc2bin_nsidc_tb.py <nc_filename>
+
+"""
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+def get_version_string(prodid, fn, default_version=5):
+    """
+    Derive the (major) version number to use from the filename
+    This expects the version to be all digits and decimal point between
+    the letter 'v' and the extension '.nc'
+
+    If product ID is 0080 (NRT TBs), then verstr is 'nrt'
+    """
+    print(f'in get_version_string(), prodid: {prodid}')
+    if prodid == 'nsidc0080':
+        ver_string = 'nrt'
+    else:
+        fn_str = str(fn)
+        print(f're.findall: {re.findall("v(.*?).nc", fn_str)}')
+        ver_string = f"v{re.findall('v(.*?).nc', fn_str)[0]}"
+
+    return ver_string
+
+
+def get_prodid(fn):
+    """
+    Return the NSIDC product name from this filename or filename string
+    """
+    if isinstance(fn, str):
+        fn_str = fn
+    else:
+        fn_str = str(fn)
+
+    if 'NSIDC0001' in fn_str:
+        prodid = 'nsidc0001'
+    elif 'NSIDC0080' in fn_str:
+        prodid = 'nsidc0080'
+    else:
+        raise RuntimeError(f'Product ID not 0001 or 0080: {fn_str}')
+
+    return prodid
+
+
+def extract_raw_binary_files(fn, outdir):
+    """Extract the original (v5) filenames for the raw binary files"""
+    # Open netCDF file
+    try:
+        ds = Dataset(fn)
+        ds.set_auto_maskandscale(False)  # don't unpack data when reading, use actual array
+    except OSError:
+        raise TypeError(f'ERROR: file is not netCDF: {fn}')
+
+    # Determine date of date in file
+    data_datestring = dt.datetime.strptime(
+        ds.getncattr('time_coverage_start')[:10],
+        '%Y-%m-%d').date().strftime('%Y%m%d')
+
+    # Determine data hemisphere
+    crs_name = ds.variables['crs'].getncattr('long_name')
+
+    if '_NH_' in crs_name:
+        hem = 'n'
+    elif '_SH_' in crs_name:
+        hem = 's'
+
+    prod_id = get_prodid(fn)
+    version_string = get_version_string(prod_id, fn)
+
+    # Extract all TB fields in this netCDF data set
+    fn_template = 'tb_{sat}_{datestr}_{ver}_{hem}{chan}.bin'
+    for sat in ds.groups.keys():
+        for tbfield in ds.groups[sat].variables.keys():
+            chan = tbfield[-3:].lower()
+            ofn = Path(outdir) / \
+                fn_template.format(
+                    sat=sat.lower(),
+                    datestr=data_datestring,
+                    ver=version_string,
+                    hem=hem,
+                    chan=chan
+                )
+
+
+            tbdata = np.array(ds.groups[sat].variables[tbfield])
+
+            tbdata.tofile(ofn)
+            print(f'  Wrote: {ofn}')
+
+
+if __name__ == '__main__':
+    try:
+        ifn = Path(sys.argv[1])
+    except IndexError:
+        raise RuntimeError('ERROR: No filename (first argument) given.')
+    except AssertionError:
+        print(f'Not a file: {ifn}')
+        raise RuntimeError('Given filename is not a file')
+
+    try:
+        outdir_name = sys.argv[2]
+    except IndexError:
+        outdir_name = './extracted_bins'
+    outdir = Path(outdir_name)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    extract_raw_binary_files(ifn, outdir)


### PR DESCRIPTION
This branch adds two nc2bin python programs. One works with NSIDC sea ice concentration netCDF files (currently nsidc0051 and nsidc0081), and the other with NSIDC TB netCDF files (currently nsidc0001 and nsidc0080).