### PR TITLE
Consolidate nc2bin tb

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,62 @@ $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_S25km_202
   Wrote: ./nt_20201101_f17_v1.1_s.bin
 ```
 
+### NSIDC Brightness Temperature Data Sets(nsidc0001, nsidc0080)
+
+The nc2bin_tb.py `python` script converts
+[DMSP SSM/I-SSMIS Daily Polar Gridded Brightness Temperatures, Version 6](https://nsidc.org/data/nsidc-0001)
+and
+[Near-Real-Time DMSP SSM/I-SSMIS Daily Polar Gridded Brightness Temperatures, Version 2](https://nsidc.org/data/nsidc-0080/versions/2)
+NetCDF data to the original binary format used in previous versions of these data sets.
+
+The script takes the path to a NetCDF file as an argument and produces binary
+files corresponding to sea ice concentration estimates from DMSP satellite
+(e.g., `f16`, `f17`, and/or `f18`) contained in the NetCDF file.
+
+The script produces outputs in a directory specified as an optional second
+command line argument or in the default location of `./extracted_bins/`.
+
+##### Script usage
+
+Requires `netcdf4` python library.
+
+```
+$ python nc2bin_tb.py /path/to/existing/netcdf/NSIDC0080_TB_PS_N12.5km_20220130_v2.0.nc ./tb0080dir_20220130
+  Wrote: tb0080dir_20220130/tb_f16_20220130_nrt_n91h.bin
+  Wrote: tb0080dir_20220130/tb_f16_20220130_nrt_n91v.bin
+  Wrote: tb0080dir_20220130/tb_f17_20220130_nrt_n91h.bin
+  Wrote: tb0080dir_20220130/tb_f17_20220130_nrt_n91v.bin
+  Wrote: tb0080dir_20220130/tb_f18_20220130_nrt_n91h.bin
+  Wrote: tb0080dir_20220130/tb_f18_20220130_nrt_n91v.bin
+$ python nc2bin_tb.py /path/to/existing/netcdf/NSIDC0080_TB_PS_S25km_20220130_v2.0.nc
+  Wrote: extracted_bins/tb_f16_20220130_nrt_s19h.bin
+  Wrote: extracted_bins/tb_f16_20220130_nrt_s19v.bin
+  Wrote: extracted_bins/tb_f16_20220130_nrt_s22v.bin
+  Wrote: extracted_bins/tb_f16_20220130_nrt_s37h.bin
+  Wrote: extracted_bins/tb_f16_20220130_nrt_s37v.bin
+  Wrote: extracted_bins/tb_f17_20220130_nrt_s19h.bin
+  Wrote: extracted_bins/tb_f17_20220130_nrt_s19v.bin
+  Wrote: extracted_bins/tb_f17_20220130_nrt_s22v.bin
+  Wrote: extracted_bins/tb_f17_20220130_nrt_s37h.bin
+  Wrote: extracted_bins/tb_f17_20220130_nrt_s37v.bin
+  Wrote: extracted_bins/tb_f18_20220130_nrt_s19h.bin
+  Wrote: extracted_bins/tb_f18_20220130_nrt_s19v.bin
+  Wrote: extracted_bins/tb_f18_20220130_nrt_s22v.bin
+  Wrote: extracted_bins/tb_f18_20220130_nrt_s37h.bin
+  Wrote: extracted_bins/tb_f18_20220130_nrt_s37v.bin
+$ python nc2bin_tb.py /path/to/existing/netcdf/NSIDC0001_TB_PS_N25km_20220202_v6.0.nc
+  Wrote: extracted_bins/tb_f17_20220202_v6.0_n19h.bin
+  Wrote: extracted_bins/tb_f17_20220202_v6.0_n19v.bin
+  Wrote: extracted_bins/tb_f17_20220202_v6.0_n22v.bin
+  Wrote: extracted_bins/tb_f17_20220202_v6.0_n37h.bin
+  Wrote: extracted_bins/tb_f17_20220202_v6.0_n37v.bin
+  Wrote: extracted_bins/tb_f18_20220202_v6.0_n19h.bin
+  Wrote: extracted_bins/tb_f18_20220202_v6.0_n19v.bin
+  Wrote: extracted_bins/tb_f18_20220202_v6.0_n22v.bin
+  Wrote: extracted_bins/tb_f18_20220202_v6.0_n37h.bin
+  Wrote: extracted_bins/tb_f18_20220202_v6.0_n37v.bin
+```
+
 ## License
 
 See [LICENSE](LICENSE), unless otherwise stated in the README file with each subdirectory.

--- a/nc2bin_nsidc_tb.py
+++ b/nc2bin_nsidc_tb.py
@@ -1,0 +1,120 @@
+"""
+nc2bin_nsidc_tb.py
+
+From a NSIDC brightness temperature netCDF file -- eg NSIDC0001 or
+NSIDC-0080 -- extract the tb fields and output in legacy format
+
+Sample usage:
+    python nc2bin_nsidc_tb.py <nc_filename>
+
+"""
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+import numpy as np
+from netCDF4 import Dataset
+
+
+def get_version_string(prodid, fn, default_version=5):
+    """
+    Derive the (major) version number to use from the filename
+    This expects the version to be all digits and decimal point between
+    the letter 'v' and the extension '.nc'
+
+    If product ID is 0080 (NRT TBs), then verstr is 'nrt'
+    """
+    print(f'in get_version_string(), prodid: {prodid}')
+    if prodid == 'nsidc0080':
+        ver_string = 'nrt'
+    else:
+        fn_str = str(fn)
+        print(f're.findall: {re.findall("v(.*?).nc", fn_str)}')
+        ver_string = f"v{re.findall('v(.*?).nc', fn_str)[0]}"
+
+    return ver_string
+
+
+def get_prodid(fn):
+    """
+    Return the NSIDC product name from this filename or filename string
+    """
+    if isinstance(fn, str):
+        fn_str = fn
+    else:
+        fn_str = str(fn)
+
+    if 'NSIDC0001' in fn_str:
+        prodid = 'nsidc0001'
+    elif 'NSIDC0080' in fn_str:
+        prodid = 'nsidc0080'
+    else:
+        raise RuntimeError(f'Product ID not 0001 or 0080: {fn_str}')
+
+    return prodid
+
+
+def extract_raw_binary_files(fn, outdir):
+    """Extract the original (v5) filenames for the raw binary files"""
+    # Open netCDF file
+    try:
+        ds = Dataset(fn)
+        ds.set_auto_maskandscale(False)  # don't unpack data when reading, use actual array
+    except OSError:
+        raise TypeError(f'ERROR: file is not netCDF: {fn}')
+
+    # Determine date of date in file
+    data_datestring = dt.datetime.strptime(
+        ds.getncattr('time_coverage_start')[:10],
+        '%Y-%m-%d').date().strftime('%Y%m%d')
+
+    # Determine data hemisphere
+    crs_name = ds.variables['crs'].getncattr('long_name')
+
+    if '_NH_' in crs_name:
+        hem = 'n'
+    elif '_SH_' in crs_name:
+        hem = 's'
+
+    prod_id = get_prodid(fn)
+    version_string = get_version_string(prod_id, fn)
+
+    # Extract all TB fields in this netCDF data set
+    fn_template = 'tb_{sat}_{datestr}_{ver}_{hem}{chan}.bin'
+    for sat in ds.groups.keys():
+        for tbfield in ds.groups[sat].variables.keys():
+            chan = tbfield[-3:].lower()
+            ofn = Path(outdir) / \
+                fn_template.format(
+                    sat=sat.lower(),
+                    datestr=data_datestring,
+                    ver=version_string,
+                    hem=hem,
+                    chan=chan
+                )
+
+
+            tbdata = np.array(ds.groups[sat].variables[tbfield])
+
+            tbdata.tofile(ofn)
+            print(f'  Wrote: {ofn}')
+
+
+if __name__ == '__main__':
+    try:
+        ifn = Path(sys.argv[1])
+    except IndexError:
+        raise RuntimeError('ERROR: No filename (first argument) given.')
+    except AssertionError:
+        print(f'Not a file: {ifn}')
+        raise RuntimeError('Given filename is not a file')
+
+    try:
+        outdir_name = sys.argv[2]
+    except IndexError:
+        outdir_name = './extracted_bins'
+    outdir = Path(outdir_name)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    extract_raw_binary_files(ifn, outdir)

--- a/nc2bin_tb.py
+++ b/nc2bin_tb.py
@@ -1,11 +1,13 @@
 """
-nc2bin_nsidc_tb.py
+nc2bin_tb.py
 
 From a NSIDC brightness temperature netCDF file -- eg NSIDC0001 or
 NSIDC-0080 -- extract the tb fields and output in legacy format
 
 Sample usage:
-    python nc2bin_nsidc_tb.py <nc_filename>
+    python nc2bin_tb.py <nc_filename> [<output_directory>]
+  eg
+    python nc2bin_tb.py NSIDC0080_TB_PS_N25km_20220130_v2.0.nc ./tb0080_20220130
 
 """
 import datetime as dt
@@ -60,7 +62,8 @@ def extract_raw_binary_files(fn, outdir):
     # Open netCDF file
     try:
         ds = Dataset(fn)
-        ds.set_auto_maskandscale(False)  # don't unpack data when reading, use actual array
+        # Don't unpack data when reading, instead use values as-stored in file
+        ds.set_auto_maskandscale(False)
     except OSError:
         raise TypeError(f'ERROR: file is not netCDF: {fn}')
 
@@ -102,6 +105,7 @@ def extract_raw_binary_files(fn, outdir):
 
 
 if __name__ == '__main__':
+    default_outdir_name = './extracted_bins'
     try:
         ifn = Path(sys.argv[1])
     except IndexError:
@@ -113,7 +117,7 @@ if __name__ == '__main__':
     try:
         outdir_name = sys.argv[2]
     except IndexError:
-        outdir_name = './extracted_bins'
+        outdir_name = default_outdir_name
     outdir = Path(outdir_name)
     outdir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
This PR extends the python nc2bin script used to extract legacy-format raw binary output files so that it works with either 0001 or 0080 input data.

This can be merged when 0080 v2 is published.

Also, when it is feasible to update the 0001 user guide, the nsidc0001/ directory can be removed and reference to those files can be removed from the README.md file because the new nc2bin_tb.py supercedes those routines.