### PR TITLE
add support for NSIDC-0079 ver 4+ (netCDF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Polar Stereographic Reformatting
 
-Python scripts for reformatting specific NSIDC SMMR-SSM/I-SSMIS data products in polar stereographic projections from NetCDF to binary.
+Python scripts for reformatting specific NSIDC SMMR-SSM/I-SSMIS data products in polar stereographic projections from netCDF to binary.
 
 ## Level of Support
 
@@ -17,7 +17,7 @@ contact nsidc@nsidc.org for more information.
 
 The python scripts in this repository require:
 * [`python`](https://www.python.org/downloads/) >=v3.9,<4.0
-* [`netcdf4`](https://unidata.github.io/netcdf4-python/) python library
+* [`netCDF4`](https://unidata.github.io/netcdf4-python/) python library
 
 These requirements are also included in the provided `environment.yml` file,
 which can be used with [conda](https://docs.conda.io/en/latest/) to install the
@@ -37,15 +37,15 @@ $ conda activate ps_nc2bin
 
 ### NSIDC Brightness Temperature Data Sets (nsidc0001 and nsidc0080)
 
-The nc2bin_tb.py `python` script converts [DMSP SSM/I-SSMIS Daily Polar Gridded Brightness Temperatures, Version 6](https://nsidc.org/data/nsidc-0001) and [Near-Real-Time DMSP SSM/I-SSMIS Daily Polar Gridded Brightness Temperatures, Version 2](https://nsidc.org/data/nsidc-0080) NetCDF data to the original binary format used in earlier versions.
+The nc2bin_tb.py `python` script converts [DMSP SSM/I-SSMIS Daily Polar Gridded Brightness Temperatures, Version 6](https://nsidc.org/data/nsidc-0001) and [Near-Real-Time DMSP SSM/I-SSMIS Daily Polar Gridded Brightness Temperatures, Version 2](https://nsidc.org/data/nsidc-0080) netCDF data to the original binary format used in earlier versions.
 
-The script takes the path to an NetCDF file as an argument and produces binary files corresponding to data from each passive microwave channel (e.g., `n19h`, `s91v`) contained in the NetCDF file.
+The script takes the path to an netCDF file as an argument and produces binary files corresponding to data from each passive microwave channel (e.g., `n19h`, `s91v`) contained in the netCDF file.
 
 Each script produces outputs in a directory provided as the second command-line argument or in the directory `./extracted_bins` if no directory name is provided.
 
 #### Python script
 
-Requires `netcdf4` python library.
+Requires `netCDF4` python package.
 
 ```
 $ python nc2bin_tb.py /path/to/existing/netcdf/NSIDC0001_TB_PS_N12.5km_20080101_v6.0.nc
@@ -72,22 +72,25 @@ $ python nc2bin_tb.py /path/to/existing/netcdf/NSIDC0080_TB_PS_S12.5km_20080101_
   Wrote: legacy_tbs/tb_f18_20220130_nrt_s37v.bin
 ```
 
-### NSIDC Sea Ice Concentration Data Sets (nsidc0051, nsidc0081)
+### NSIDC Sea Ice Concentration Data Sets (nsidc0051, nsidc0079, nsidc0081)
 
-The nc2bin_siconc.py `python` script converts [Sea Ice Concentrations from Nimbus-7 SMMR and DMSP SSM/I-SSMIS Passive Microwave Data, Verson 2](https://nsidc.org/data/nsidc-0051) and [Near-Real-Time DMSP
+The nc2bin_siconc.py `python` script converts [Sea Ice Concentrations from Nimbus-7 SMMR and DMSP SSM/I-SSMIS Passive Microwave Data, Verson 2](https://nsidc.org/data/nsidc-0051), [Bootstrap Sea Ice Concentrations from Nimbus-7 SMMR and DMSP SSM/I-SSMIS, Version 4](https://nsidc.org/data/nsidc-0079), and [Near-Real-Time DMSP
 SSMIS Daily Polar Gridded Sea Ice Concentrations, Version
 2](https://nsidc.org/data/nsidc-0081) NetCDF data to the original binary format
 from earlier versions.
 
-The script takes the path to a NetCDF file as an argument and produces binary
+The script takes the path to a netCDF file as an argument and produces binary
 files corresponding to sea ice concentration estimates from DMSP satellite
-(e.g., `f16`, `f17`, `f18`) contained in the NetCDF file.
+(e.g., `f16`, `f17`, `f18`) contained in the netCDF file.  NetCDF files are
+created for each day, even if no ice concentration fields are calculated.
+When run with netCDF files with no sea ice concentration fields, the script
+does not produce any binary output files.
 
 The script produces outputs in the directory from which the program was invoked.
 
 ##### Script usage
 
-Requires `netcdf4` python library.
+Requires `netCDF4` python package.
 
 ```
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0081_SEAICE_PS_N25km_20211101_v2.0.nc 
@@ -104,6 +107,29 @@ $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_N25km_199
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_S25km_20201101_v2.0.nc 
   Wrote: ./nt_20201101_f17_v1.1_s.bin
 ```
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_19870501_v4.0.nc 
+  Wrote: ./nt_19900301_f08_v1.1_n.bin
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_S25km_20201101_v2.0.nc 
+  Wrote: ./nt_20201101_f17_v1.1_s.bin
+```
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_19870301_v4.0.nc
+  Wrote: bt_19870301_n07_v4.0_n.bin
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_19870401_v4.0.nc
+                 <<-- Note: No output because data field is empty
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_19870501_v4.0.nc
+                 <<-- Note: No output because data field is empty
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_198705_v4.0.nc
+  Wrote: bt_198705_n07_v4.0_n.bin
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_20220701_v4.0.nc
+  Wrote: bt_20220701_f17_v4.0_n.bin
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_202207_v4.0.nc
+  Wrote: bt_202207_f17_v4.0_n.bin
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_S25km_20220701_v4.0.nc
+  Wrote: bt_20220701_f17_v4.0_s.bin
+$ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_S25km_202207_v4.0.nc
+  Wrote: bt_202207_f17_v4.0_s.bin
+
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -106,12 +106,11 @@ $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_N25km_199
   Wrote: ./nt_19900301_f08_v1.1_n.bin
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0051_SEAICE_PS_S25km_20201101_v2.0.nc 
   Wrote: ./nt_20201101_f17_v1.1_s.bin
-```
+
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_19870501_v4.0.nc 
   Wrote: ./nt_19900301_f08_v1.1_n.bin
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_S25km_20201101_v2.0.nc 
   Wrote: ./nt_20201101_f17_v1.1_s.bin
-```
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_19870301_v4.0.nc
   Wrote: bt_19870301_n07_v4.0_n.bin
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_N25km_19870401_v4.0.nc
@@ -128,6 +127,7 @@ $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_S25km_202
   Wrote: bt_20220701_f17_v4.0_s.bin
 $ python nc2bin_siconc.py /path/to/existing/netcdf/NSIDC0079_SEAICE_PS_S25km_202207_v4.0.nc
   Wrote: bt_202207_f17_v4.0_s.bin
+```
 
 
 


### PR DESCRIPTION
This PR should *NOT* be merged until version 4 of NSIDC-0079 is released (expected Summer or Fall of 2023?).   

NSIDC-0079 versions before 4.0 are already in raw binary format and do not need this code.

0079v4 repackages the Bootstrap fields in netCDF format, and users can use this update to nc2bin_siconc.py to re-construct the data in the legacy raw binary format.